### PR TITLE
rustc-serialize is updated from 0.3.5 to 0.3.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Graham Lee <ghmlee@cosmos.io>"]
 [dependencies]
 unix_socket = "0.2.1"
 hyper = "0.3.2"
-rustc-serialize = "0.3.5"
+rustc-serialize = "0.3.6"


### PR DESCRIPTION
rustc-serialize is updated from 0.3.5 to 0.3.6.