### PR TITLE
rustc is updated.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 authors = ["Graham Lee <ghmlee@cosmos.io>"]
 
 [dependencies]
-docker = "0.0.7"
-cosmos = "0.0.1"
-rustc-serialize = "0.3.10"
+docker = "0.0.8"
+cosmos = "0.0.2"
+rustc-serialize = "0.3.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(std_misc)]
-#![feature(thread_sleep)]
-
 extern crate docker;
 extern crate cosmos;
 extern crate rustc_serialize;
@@ -8,7 +5,6 @@ extern crate rustc_serialize;
 mod model;
 
 use std::{env, thread};
-use std::time::Duration;
 
 use model::{Container, CosmosContainerDecodable};
 
@@ -31,7 +27,7 @@ fn run(host: &str, planet_name: &str) {
         };
 
         // setting interval
-        thread::sleep(Duration::seconds(1));
+        thread::sleep_ms(1000);
 
         let delayed_stats = match docker.get_stats(&container) {
             Err(e) => { println!("{}", e); return; }
@@ -70,6 +66,6 @@ fn main() {
     
     loop {
         run(&host, &planet_name);
-        thread::sleep(Duration::seconds(5));
+        thread::sleep_ms(5000);
     }
 }


### PR DESCRIPTION
I have worked in
* docker is updated to v0.0.8.
* cosmos is updated to v0.0.2.
* rustc-serialize is updated to v0.3.11.
* feature std_misc, thread_sleep are unnecessary.
* thread::sleep() is replaced to thread::sleep_ms() because of deprecation.